### PR TITLE
fix: Remove unused mut warnings and handle Result

### DIFF
--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -4786,7 +4786,7 @@ mod tests {
                 pid,
             );
             assert!(result.is_ok());
-            let (mut state, output) = result.unwrap();
+            let (state, output) = result.unwrap();
             let fd = match output {
                 SyscallOutput::FileDescriptor(fd) => fd,
                 _ => panic!("Expected FileDescriptor"),

--- a/shared/src/vfs.rs
+++ b/shared/src/vfs.rs
@@ -2261,14 +2261,14 @@ mod tests {
 
     #[test]
     fn test_vfs_creation() {
-        let mut vfs = VirtualFileSystem::new();
+        let vfs = VirtualFileSystem::new();
         assert_eq!(vfs.cwd(), &PathBuf::from("/"));
         assert_eq!(vfs.file_count(), 0);
     }
 
     #[test]
     fn test_vfs_clone_cheap() {
-        let mut vfs = VirtualFileSystem::new();
+        let vfs = VirtualFileSystem::new();
         let _cloned = vfs.clone();
         // Clone should be O(1) due to persistent data structures
         assert_eq!(vfs, _cloned);
@@ -2544,7 +2544,7 @@ mod tests {
 
     #[test]
     fn test_list_directory_not_found() {
-        let mut vfs = VirtualFileSystem::new();
+        let vfs = VirtualFileSystem::new();
         let result = vfs.list_directory(&PathBuf::from("/nonexistent"));
         assert_eq!(result, Err(VfsError::NotFound));
     }
@@ -2644,7 +2644,7 @@ mod tests {
 
     #[test]
     fn test_root_directory_exists() {
-        let mut vfs = VirtualFileSystem::new();
+        let vfs = VirtualFileSystem::new();
         assert!(
             vfs.is_directory(&PathBuf::from("/")),
             "Root directory should always exist"
@@ -3791,7 +3791,7 @@ mod tests {
 
     #[test]
     fn test_stat_nonexistent_file() {
-        let mut vfs = VirtualFileSystem::new();
+        let vfs = VirtualFileSystem::new();
         let result = vfs.stat(&PathBuf::from("/nonexistent.txt"));
         assert_eq!(result, Err(VfsError::NotFound));
     }

--- a/wos/src/lib.rs
+++ b/wos/src/lib.rs
@@ -7665,13 +7665,13 @@ mod coverage_red_tests {
     // MB9: 300 ultra-targeted micro-tests - final push to 95%
     #[test]
     fn mb9_001() {
-        let mut w = WosWasm::new();
+        let w = WosWasm::new();
         let _ = w.get_state();
     }
     #[test]
     fn mb9_002() {
         let mut w = WosWasm::new();
-        w.set_state("{}");
+        let _ = w.set_state("{}");
     }
     #[test]
     fn mb9_003() {


### PR DESCRIPTION
- Fixed 5 unused mut warnings in shared/src/vfs.rs
- Fixed 1 unused mut warning in kernel/src/syscall.rs
- Fixed 1 unused mut warning in wos/src/lib.rs
- Added let _ = to handle unused Result in wos/src/lib.rs:7674

All 3010 tests passing. Zero clippy warnings.