### PR TITLE
[WOS-QUALITY] Fix all clippy warnings (35 → 0)

### DIFF
--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -3753,7 +3753,6 @@ mod tests {
     }
 
     /// Property Tests (2 tests)
-
     #[cfg(test)]
     mod sleep_properties {
         use super::*;
@@ -6695,7 +6694,10 @@ mod tests {
                 .unwrap();
             state
                 .vfs
-                .write_file(&std::path::PathBuf::from("/bin/child_prog"), b"child code".to_vec())
+                .write_file(
+                    &std::path::PathBuf::from("/bin/child_prog"),
+                    b"child code".to_vec(),
+                )
                 .unwrap();
 
             // Exec in child process
@@ -6739,7 +6741,10 @@ mod tests {
             );
 
             assert!(result.is_err());
-            assert!(matches!(result.unwrap_err(), KernelError::InvalidParameters(_)));
+            assert!(matches!(
+                result.unwrap_err(),
+                KernelError::InvalidParameters(_)
+            ));
         }
 
         #[test]
@@ -6767,7 +6772,10 @@ mod tests {
             );
 
             assert!(result.is_err());
-            assert!(matches!(result.unwrap_err(), KernelError::InvalidParameters(_)));
+            assert!(matches!(
+                result.unwrap_err(),
+                KernelError::InvalidParameters(_)
+            ));
         }
 
         #[test]
@@ -6777,7 +6785,8 @@ mod tests {
             let mut proc = Process::new(pid, None);
 
             // Set initial environment
-            proc.env.insert("OLD_VAR".to_string(), "old_value".to_string());
+            proc.env
+                .insert("OLD_VAR".to_string(), "old_value".to_string());
             state.add_process(proc);
 
             // Create executable
@@ -6787,7 +6796,10 @@ mod tests {
                 .unwrap();
             state
                 .vfs
-                .write_file(&std::path::PathBuf::from("/bin/prog"), b"program code".to_vec())
+                .write_file(
+                    &std::path::PathBuf::from("/bin/prog"),
+                    b"program code".to_vec(),
+                )
                 .unwrap();
 
             // Exec with new environment
@@ -6831,7 +6843,10 @@ mod tests {
                 .unwrap();
             state
                 .vfs
-                .write_file(&std::path::PathBuf::from("/bin/multi_arg"), b"code".to_vec())
+                .write_file(
+                    &std::path::PathBuf::from("/bin/multi_arg"),
+                    b"code".to_vec(),
+                )
                 .unwrap();
 
             // Exec with multiple arguments
@@ -6938,7 +6953,10 @@ mod tests {
             );
 
             assert!(result.is_err());
-            assert!(matches!(result.unwrap_err(), KernelError::InvalidParameters(_)));
+            assert!(matches!(
+                result.unwrap_err(),
+                KernelError::InvalidParameters(_)
+            ));
         }
 
         #[test]
@@ -7000,10 +7018,8 @@ mod tests {
             let mut proc = Process::new(pid, None);
 
             // Pre-block some signals
-            proc.blocked_signals
-                .add(crate::signals::Signal::SIGINT);
-            proc.blocked_signals
-                .add(crate::signals::Signal::SIGTERM);
+            proc.blocked_signals.add(crate::signals::Signal::SIGINT);
+            proc.blocked_signals.add(crate::signals::Signal::SIGTERM);
             state.add_process(proc);
 
             // Unblock SIGINT
@@ -7063,16 +7079,15 @@ mod tests {
             let mut proc = Process::new(pid, None);
 
             // Pre-block SIGINT
-            proc.blocked_signals
-                .add(crate::signals::Signal::SIGINT);
+            proc.blocked_signals.add(crate::signals::Signal::SIGINT);
             state.add_process(proc);
 
             // Block SIGTERM, unblock SIGINT in same call
             let result = dispatch_syscall(
                 state,
                 SystemCall::Sigprocmask {
-                    block: vec![15],   // SIGTERM
-                    unblock: vec![2],  // SIGINT
+                    block: vec![15],  // SIGTERM
+                    unblock: vec![2], // SIGINT
                 },
                 pid,
             );
@@ -7111,14 +7126,7 @@ mod tests {
             let (state, _) = result.unwrap();
 
             // Send SIGTERM to process
-            let result = dispatch_syscall(
-                state,
-                SystemCall::Kill {
-                    pid,
-                    signal: 15,
-                },
-                pid,
-            );
+            let result = dispatch_syscall(state, SystemCall::Kill { pid, signal: 15 }, pid);
             assert!(result.is_ok());
             let (state, _) = result.unwrap();
 

--- a/shared/src/parser.rs
+++ b/shared/src/parser.rs
@@ -559,55 +559,55 @@ mod tests {
     #[test]
     fn test_handle_quote_toggle_single() {
         let (new_single, new_double, had_quotes) = handle_quote_toggle('\'', false, false);
-        assert_eq!(new_single, true);
-        assert_eq!(new_double, false);
-        assert_eq!(had_quotes, true);
+        assert!(new_single);
+        assert!(!new_double);
+        assert!(had_quotes);
     }
 
     #[test]
     fn test_handle_quote_toggle_double() {
         let (new_single, new_double, had_quotes) = handle_quote_toggle('"', false, false);
-        assert_eq!(new_single, false);
-        assert_eq!(new_double, true);
-        assert_eq!(had_quotes, true);
+        assert!(!new_single);
+        assert!(new_double);
+        assert!(had_quotes);
     }
 
     #[test]
     fn test_handle_quote_toggle_close_single() {
         let (new_single, new_double, had_quotes) = handle_quote_toggle('\'', true, false);
-        assert_eq!(new_single, false);
-        assert_eq!(new_double, false);
-        assert_eq!(had_quotes, true);
+        assert!(!new_single);
+        assert!(!new_double);
+        assert!(had_quotes);
     }
 
     #[test]
     fn test_should_end_token_whitespace() {
-        assert_eq!(should_end_token(' ', false, false, 0, 0), true);
-        assert_eq!(should_end_token('\t', false, false, 0, 0), true);
+        assert!(should_end_token(' ', false, false, 0, 0));
+        assert!(should_end_token('\t', false, false, 0, 0));
     }
 
     #[test]
     fn test_should_end_token_in_quotes() {
-        assert_eq!(should_end_token(' ', true, false, 0, 0), false);
-        assert_eq!(should_end_token(' ', false, true, 0, 0), false);
+        assert!(!should_end_token(' ', true, false, 0, 0));
+        assert!(!should_end_token(' ', false, true, 0, 0));
     }
 
     #[test]
     fn test_should_end_token_in_command_substitution() {
         // Space inside $(...)  should not end token
-        assert_eq!(should_end_token(' ', false, false, 1, 0), false);
-        assert_eq!(should_end_token('\t', false, false, 1, 0), false);
+        assert!(!should_end_token(' ', false, false, 1, 0));
+        assert!(!should_end_token('\t', false, false, 1, 0));
         // Space outside $(...)  should end token
-        assert_eq!(should_end_token(' ', false, false, 0, 0), true);
+        assert!(should_end_token(' ', false, false, 0, 0));
     }
 
     #[test]
     fn test_should_end_token_in_parameter_expansion() {
         // Space inside ${...} should not end token
-        assert_eq!(should_end_token(' ', false, false, 0, 1), false);
-        assert_eq!(should_end_token('\t', false, false, 0, 1), false);
+        assert!(!should_end_token(' ', false, false, 0, 1));
+        assert!(!should_end_token('\t', false, false, 0, 1));
         // Space outside ${...} should end token
-        assert_eq!(should_end_token(' ', false, false, 0, 0), true);
+        assert!(should_end_token(' ', false, false, 0, 0));
     }
 
     // Property-based tests using proptest
@@ -702,10 +702,10 @@ mod tests {
             ) {
                 // Build input with variable spacing (1-5 spaces between words)
                 let mut input = words[0].clone();
-                for i in 1..words.len() {
+                for (i, word) in words.iter().enumerate().skip(1) {
                     let num_spaces = (i % 5) + 1; // 1-5 spaces
                     input.push_str(&" ".repeat(num_spaces));
-                    input.push_str(&words[i]);
+                    input.push_str(word);
                 }
 
                 let (cmd, args) = parse_command(&input);

--- a/shared/src/pipeline.rs
+++ b/shared/src/pipeline.rs
@@ -864,16 +864,16 @@ mod tests {
     #[test]
     fn test_update_quote_state() {
         let (in_single, in_double) = update_quote_state('\'', false, false);
-        assert_eq!(in_single, true);
-        assert_eq!(in_double, false);
+        assert!(in_single);
+        assert!(!in_double);
 
         let (in_single, in_double) = update_quote_state('"', false, false);
-        assert_eq!(in_single, false);
-        assert_eq!(in_double, true);
+        assert!(!in_single);
+        assert!(in_double);
 
         let (in_single, in_double) = update_quote_state('\'', true, false);
-        assert_eq!(in_single, false);
-        assert_eq!(in_double, false);
+        assert!(!in_single);
+        assert!(!in_double);
     }
 }
 

--- a/shared/src/vfs.rs
+++ b/shared/src/vfs.rs
@@ -5444,10 +5444,8 @@ mod tests {
                         if vfs.create_file(child_path, vec![]).is_ok() {
                             created_count += 1;
                         }
-                    } else {
-                        if vfs.create_directory(child_path).is_ok() {
-                            created_count += 1;
-                        }
+                    } else if vfs.create_directory(child_path).is_ok() {
+                        created_count += 1;
                     }
                 }
 
@@ -6121,7 +6119,6 @@ mod tests {
     }
 
     /// Property Tests (2 tests)
-
     #[cfg(test)]
     mod xattr_properties {
         use super::*;
@@ -6156,12 +6153,11 @@ mod tests {
                 vfs.create_file(path.clone(), vec![]).ok();
 
                 let attr_name = format!("user.{}", name);
-                if vfs.setxattr(&path, &attr_name, &value).is_ok() {
-                    if vfs.removexattr(&path, &attr_name).is_ok() {
+                if vfs.setxattr(&path, &attr_name, &value).is_ok()
+                    && vfs.removexattr(&path, &attr_name).is_ok() {
                         let result = vfs.getxattr(&path, &attr_name);
                         prop_assert_eq!(result, Err(VfsError::NotFound));
                     }
-                }
             }
         }
     }

--- a/wos/src/lib.rs
+++ b/wos/src/lib.rs
@@ -5866,7 +5866,7 @@ mod coverage_red_tests {
     fn test_mb3_var_dollar() {
         let mut wos = WosWasm::new();
         wos.execute_command("X=hi");
-        assert!(wos.execute_command("echo $X").len() > 0);
+        assert!(!wos.execute_command("echo $X").is_empty());
     }
     #[test]
     fn test_mb3_var_brace() {

--- a/wos/src/script_executor.rs
+++ b/wos/src/script_executor.rs
@@ -1336,8 +1336,8 @@ fn create_test_executor() -> impl FnMut(&str) -> (String, i32) {
     move |line: &str| {
         let line = line.trim();
         // Handle echo command
-        if line.starts_with("echo ") {
-            let output = line[5..].trim().to_string();
+        if let Some(stripped) = line.strip_prefix("echo ") {
+            let output = stripped.trim().to_string();
             return (output, 0);
         }
         // Handle invalid_command for error testing
@@ -1966,8 +1966,8 @@ mod coverage_red_tests {
                 return ("".to_string(), 1); // Failure
             }
             // Handle echo command
-            if line.starts_with("echo ") {
-                let output = line[5..].trim().to_string();
+            if let Some(stripped) = line.strip_prefix("echo ") {
+                let output = stripped.trim().to_string();
                 return (output, 0);
             }
             // Handle true/false commands
@@ -2043,8 +2043,7 @@ mod coverage_red_tests {
 
         let result = ScriptExecutor::execute(&script, &mut vfs, &mut vars, &mut executor);
         // While loop might not be fully implemented, so check for error or success
-        if result.is_ok() {
-            let exec_result = result.unwrap();
+        if let Ok(exec_result) = result {
             // Output length is always valid (usize is unsigned)
             let _ = exec_result.output.len();
         }
@@ -2068,7 +2067,7 @@ mod coverage_red_tests {
         assert!(result.is_ok());
         let exec_result = result.unwrap();
         // Should echo each value
-        assert!(exec_result.output.len() > 0);
+        assert!(!exec_result.output.is_empty());
     }
 
     // Lines 118-132: case statement execution


### PR DESCRIPTION
Resolved 35 clippy warnings across the codebase:
- Fixed unnecessary_unwrap: Use if-let pattern (script_executor.rs:2046)
- Fixed len_zero: Use !is_empty() instead of len() > 0 (2 occurrences)
- Fixed manual_strip: Use strip_prefix() instead of manual slicing (2 occurrences)
- Fixed bool_assert_comparison: Use assert!() for bool values (25 occurrences, auto-fixed)
- Fixed empty_line_after_doc_comments: Remove blank lines after doc comments (2 occurrences)
- Fixed needless_range_loop: Use enumerate() instead of range indexing (parser.rs:705)
- Fixed collapsible_if and collapsible_else_if (2 occurrences, auto-fixed)

All 3,036 tests passing after changes.

Quality metrics:
- Clippy warnings: 35 → 0 ✅
- Tests: 3,036 passing (100%)
- Code formatting: ✅ rustfmt applied