### PR TITLE
[WOS-DOCS] docs: Update documentation for WOS-026, WOS-027, and clipp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Signal Handler Registration (WOS-027)**: Implemented sigaction and sigprocmask syscalls
+  - Sigaction: Register custom signal handlers, set ignore/terminate actions
+  - Sigprocmask: Block/unblock signals atomically
+  - POSIX-compliant: SIGKILL cannot be caught or blocked
+  - Tests: 9 comprehensive tests covering all signal handler scenarios
+  - Location: `kernel/src/syscall.rs` (+352 lines)
+  - Commit: f0aeb14
+
+- **Exec System Call (WOS-026)**: Process image replacement functionality
+  - Replace current process with new program while preserving PID
+  - Environment variable management and replacement
+  - Program arguments stored in VirtualMemory
+  - File descriptor preservation across exec
+  - Tests: 6 comprehensive tests covering exec behavior and error paths
+  - Location: `kernel/src/syscall.rs` (+321 lines), `kernel/src/memory.rs` (+8 lines), `kernel/src/state.rs` (+3 lines)
+  - Commit: fcfc427
+
+### Quality
+- **Clippy Warnings Eliminated**: Fixed all 35 clippy warnings → 0 warnings
+  - Fixed unnecessary_unwrap: Use if-let pattern
+  - Fixed len_zero: Use !is_empty() instead of len() > 0
+  - Fixed manual_strip: Use strip_prefix() for string operations
+  - Fixed bool_assert_comparison: Use assert!() for boolean values (25 occurrences)
+  - Fixed empty_line_after_doc_comments: Remove blank lines
+  - Fixed needless_range_loop: Use enumerate() instead of range indexing
+  - Fixed collapsible_if patterns: Simplified conditional logic
+  - All 3,036 tests passing after refactoring
+  - Files modified: 6 files across kernel, shared, and wos crates
+  - Commit: 84ac6f6
+
 ## [0.3.2] - 2025-11-15
 
 ### Testing

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,10 +4,10 @@
 
 WOS (WebAssembly Operating System) is an educational microkernel designed to demonstrate OS concepts in a pure Rust, safe environment that compiles to WebAssembly.
 
-**Current Status**: 23 tickets completed across 6 development phases + Documentation phase
-**Total Tests**: 22,320 passing (277 Rust: 159 kernel + 17 shared + 45 userspace + 56 wos + 22,043 Frontend: 43 unit + 22,000 property + 39 benchmarks + 29 E2E)
+**Current Status**: 25+ tickets completed across 7 development phases + Documentation phase
+**Total Tests**: 25,079+ passing (3,036 Rust: 2,025 wos + 317 kernel + 366 shared + 324 userspace + 4 integration + 22,043 Frontend: 43 unit + 22,000 property + 39 benchmarks + 211 E2E scenarios)
 **Test Coverage**: Exceeding 85% target (94.11% Rust backend) with extensive property-based testing
-**Code Quality**: Zero unsafe code, all clippy lints passing, comprehensive mutation testing (98.5% mutation score)
+**Code Quality**: Zero unsafe code, zero clippy warnings, comprehensive mutation testing (98.5% mutation score)
 **TDG Grade**: A+ (96-97%) - Elite-tier quality across entire codebase
 **Documentation**: 318KB comprehensive documentation across 8 documents
   - Architecture & Design: 132KB (3 specifications with Toyota Way principles)
@@ -48,7 +48,7 @@ WOS (WebAssembly Operating System) is an educational microkernel designed to dem
 - ✅ **WOS-021**: Multi-format export (JSON/HTML/Markdown/SARIF) and final validation
 - ✅ **WOS-022**: Frontend testing infrastructure with Deno (43 unit + 22,000 property + 39 benchmarks)
 
-### Phase 7: Documentation (Week 18)
+### Phase 7: Advanced Features & Documentation (Week 18+)
 - ✅ **WOS-023**: Comprehensive testing strategy documentation (v1.1, 88KB)
   - Tool version table with MSRV and update guide
   - Troubleshooting FAQ (15+ common issues with solutions)
@@ -64,6 +64,19 @@ WOS (WebAssembly Operating System) is an educational microkernel designed to dem
   - Complete Playwright test examples with TypeScript
   - Chaos engineering and long-running stability tests
   - 10-week implementation roadmap
+- ✅ **WOS-026**: Exec system call implementation
+  - Process image replacement while preserving PID
+  - Environment variable management and replacement
+  - Program arguments stored in VirtualMemory
+  - File descriptor preservation across exec
+  - Tests: 6 comprehensive tests covering exec behavior and error paths
+  - Location: kernel/src/syscall.rs (+321 lines)
+- ✅ **WOS-027**: Signal handler registration
+  - Sigaction syscall: Register custom signal handlers, set ignore/terminate actions
+  - Sigprocmask syscall: Block/unblock signals atomically
+  - POSIX-compliant: SIGKILL cannot be caught or blocked
+  - Tests: 9 comprehensive tests covering all signal handler scenarios
+  - Location: kernel/src/syscall.rs (+352 lines)
 
 ## Architecture Highlights
 
@@ -75,25 +88,29 @@ WOS (WebAssembly Operating System) is an educational microkernel designed to dem
 
 ### Key Components
 
-#### Kernel (159 tests)
-- **Process Management**: Fork/exec model with parent-child relationships
+#### Kernel (317 tests)
+- **Process Management**: Fork/exec model with parent-child relationships (exec syscall)
 - **Memory Management**: Page-based virtual memory with read/write/execute permissions
-- **System Calls**: 11 implemented syscalls (GetPid, Fork, Exit, WaitPid, Open, Close, Read, Write, Mmap, Munmap, Send, Recv)
+- **System Calls**: 13 implemented syscalls (GetPid, Fork, Exec, Exit, WaitPid, Open, Close, Read, Write, Mmap, Munmap, Sigaction, Sigprocmask, Send, Recv)
+- **Signal Handling**: Custom signal handlers with blocking/unblocking (POSIX-compliant)
 - **Scheduler**: Round-robin with O(1) operations
 - **File System**: VFS with permissions + dynamic ProcFS
 - **IPC**: Message passing with FIFO ordering
 - **Debugging**: Time-travel debugging with full state snapshots
 
-#### Shared (17 tests)
+#### Shared (366 tests)
 - **VFS**: In-memory file system with persistent data structures
 - **Context**: Deterministic execution context
+- **Parser**: Command parsing and tokenization
+- **Pipeline**: Command pipeline execution
 
-#### Userspace (45 tests)
+#### Userspace (324 tests)
 - **Init Process**: PID 1 with shell launching and orphan reaping
 - **Shell Process**: Command parsing, built-ins, history, environment variables
 - **User Programs**: echo, ls, ps with syscall integration
+- **Script Executor**: Bash-compatible script execution
 
-#### WASM Layer (56 tests)
+#### WASM Layer (2,025 tests)
 - **WASM Bindings**: wasm-bindgen wrapper for browser integration
 - **State Persistence**: JSON serialization for getState/setState
 - **Syscall Interface**: JSON-based syscall execution from JavaScript

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An educational microkernel operating system written in pure Rust that compiles t
 
 - **🦀 Pure Rust**: 100% safe Rust with `#![forbid(unsafe_code)]` - zero undefined behavior
 - **🌐 Browser-Native**: Compiles to WASM, runs in any modern browser without plugins
-- **🧪 Elite Testing**: 452 unit tests + 147 E2E tests with 85%+ coverage
+- **🧪 Elite Testing**: 3,036 Rust unit tests + 22,043 Frontend tests + 211 E2E test scenarios with 94.11% coverage
 - **⚡ Functional Design**: Pure functional syscalls with immutable state transitions
 - **🔍 Time-Travel Debugging**: Bidirectional execution replay with full state snapshots
 - **📊 Quality Metrics**: Real-time TDG dashboard (99.3/100 A+) with JSON/HTML export
@@ -174,12 +174,13 @@ State flows in, new state + output flow out. No global state, no side effects.
 
 ## System Calls
 
-WOS implements 11 core syscalls:
+WOS implements 13 core syscalls:
 
 | Syscall | Description |
 |---------|-------------|
 | `GetPid` | Get current process ID |
 | `Fork` | Create child process |
+| `Exec` | Replace process image with new program |
 | `Exit` | Terminate process |
 | `WaitPid` | Wait for child termination |
 | `Open` | Open file descriptor |
@@ -188,28 +189,33 @@ WOS implements 11 core syscalls:
 | `Write` | Write to file descriptor |
 | `Mmap` | Map memory pages |
 | `Munmap` | Unmap memory pages |
+| `Sigaction` | Register signal handlers |
+| `Sigprocmask` | Block/unblock signals |
 | `Send` / `Recv` | Message-passing IPC |
 
 ## Project Structure
 
 ```
 wos/
-├── kernel/          # Core microkernel (159 tests)
+├── kernel/          # Core microkernel (317 tests)
 │   ├── state.rs     # Process and kernel state types
 │   ├── scheduler.rs # Round-robin scheduler
 │   ├── memory.rs    # Virtual memory management
-│   ├── syscall.rs   # System call implementations
+│   ├── syscall.rs   # System call implementations (13 syscalls)
 │   └── trace.rs     # Time-travel debugging
-├── shared/          # Shared types (17 tests)
+├── shared/          # Shared types (366 tests)
 │   ├── vfs.rs       # Virtual file system
-│   └── context.rs   # Execution context
-├── userspace/       # User programs (45 tests)
+│   ├── context.rs   # Execution context
+│   ├── parser.rs    # Command parsing and tokenization
+│   └── pipeline.rs  # Command pipeline execution
+├── userspace/       # User programs (324 tests)
 │   ├── init.rs      # PID 1 init process
 │   ├── shell.rs     # Interactive shell
 │   └── programs.rs  # User programs (echo, ls, ps)
-├── wos/             # WASM bindings (56 tests)
+├── wos/             # WASM bindings (2,025 tests)
 │   ├── lib.rs       # wasm-bindgen wrapper
-│   └── quality.rs   # TDG quality metrics
+│   ├── quality.rs   # TDG quality metrics
+│   └── script_executor.rs  # Bash-compatible script execution
 ├── dist/wos/        # Frontend (22,043 tests)
 │   ├── index.html   # Terminal UI
 │   ├── app.js       # Frontend logic
@@ -227,12 +233,12 @@ WOS follows extreme Test-Driven Development (TDD):
 ### Test Coverage
 
 - **94.11%** Rust backend coverage
-- **23,376** total tests (546 unit + 22,000 property + 211 E2E scenarios + 107 canary + 411 mutation + 101 other)
+- **25,079+** total tests (3,036 Rust unit + 22,043 Frontend [43 unit + 22,000 property + 39 benchmarks] + 211 E2E scenarios + 107 canary + 411 mutation tests)
 - **98.5%** mutation score (411 mutants)
 
 ### Test Types
 
-1. **Unit Tests**: 546 Rust + Frontend tests
+1. **Unit Tests**: 3,036 Rust unit tests + 43 Frontend unit tests
 2. **Property Tests**: 42 Rust + 22 Frontend = 64 properties generating 22,000+ test cases
 3. **Integration Tests**: Syscall pipelines, fork/wait workflows
 4. **E2E Tests**: 211 test scenarios across 5 browsers (Chromium, Firefox, WebKit, Mobile Chrome, Mobile Safari) = 1,055 total tests

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -1847,18 +1847,25 @@ future_phases:
   - id: phase-7
     name: "Advanced Features"
     status: partially_completed
-    completion_date: "2025-11-17"
+    completion_date: "2025-11-18"
     completion_notes: |
-      Completed 4 core advanced features in this session:
+      Completed 6 core advanced features across two sessions:
+
+      Session 1 (2025-11-17):
       - WOS-022: Priority Scheduling with aging (8 levels, starvation prevention)
       - WOS-014: Synchronization Primitives (Mutex with deadlock detection, Semaphore)
       - WOS-013: Shared Memory IPC (reference counting, multi-process access)
       - DevFS Special Files (/dev/null, /dev/zero, /dev/random with deterministic RNG)
 
+      Session 2 (2025-11-18):
+      - WOS-026: Exec system call (process image replacement, preserves PID)
+      - WOS-027: Signal handler registration (sigaction & sigprocmask, POSIX-compliant)
+      - WOS-QUALITY: Fix all clippy warnings (35 → 0)
+
       Statistics:
-      - Total Lines Added: 1,706 lines
-      - Total Tests Added: 46 tests (7 + 19 + 13 + 7)
-      - All 330 tests passing
+      - Total Lines Added: 2,379 lines (+673 in session 2)
+      - Total Tests Added: 61 tests (+15 in session 2: 6 exec + 9 signal)
+      - All 3,036 tests passing
       - 0 clippy warnings
 
       Commits:
@@ -1866,17 +1873,20 @@ future_phases:
       - a04ab58: [WOS-014] feat: Implement synchronization primitives (Mutex, Semaphore)
       - 30396ac: [WOS-013] feat: Implement shared memory IPC
       - 95023fa: [WOS-DEVFS] feat: Implement DevFS special files
+      - fcfc427: [WOS-026] feat: Implement Exec system call
+      - f0aeb14: [WOS-027] feat: Implement signal handler registration (sigaction & sigprocmask)
+      - 84ac6f6: [WOS-QUALITY] Fix all clippy warnings (35 → 0)
     features_completed:
       - "✅ Priority scheduling (WOS-022)"
       - "✅ Synchronization primitives (WOS-014)"
       - "✅ Shared memory IPC (WOS-013)"
       - "✅ Special filesystems (DevFS: /dev/null, /dev/zero, /dev/random)"
+      - "✅ Exec system call (WOS-026)"
+      - "✅ Signal handler registration (WOS-027: sigaction & sigprocmask)"
     features_deferred:
       - "Preemptive multitasking (WOS-023)"
       - "Virtual memory paging (WOS-024)"
       - "Network stack (WOS-025)"
-      - "Exec system call (WOS-026)"
-      - "Signals (WOS-027)"
       - "Pipes and redirection (WOS-028)"
       - "Multi-core support (WOS-029)"
       - "Debugging tools (WOS-030)"


### PR DESCRIPTION
…y fixes

Updated all project documentation to reflect recent changes:

**CHANGELOG.md**:
- Added WOS-027: Signal handler registration (sigaction & sigprocmask)
- Added WOS-026: Exec system call implementation
- Added WOS-QUALITY: Clippy warnings fix (35 → 0)

**PROGRESS.md**:
- Updated test counts: 25,079+ total tests (3,036 Rust + 22,043 Frontend + 211 E2E)
- Updated kernel: 317 tests (+15 from WOS-026 and WOS-027)
- Updated syscall count: 13 syscalls (added Exec, Sigaction, Sigprocmask)
- Added WOS-026 and WOS-027 to Phase 7 completed tickets
- Updated component test counts (Shared: 366, Userspace: 324, WASM: 2,025)

**README.md**:
- Updated syscall table: 11 → 13 syscalls
- Updated test counts: 3,036 Rust unit tests + 22,043 Frontend tests
- Updated test coverage summary: 25,079+ total tests
- Updated project structure with current test counts per crate

**roadmap.yaml**:
- Updated Phase 7 completion date: 2025-11-18
- Added Session 2 completion notes (WOS-026, WOS-027, clippy fixes)
- Updated statistics: 2,379 total lines, 61 tests, 3,036 passing
- Moved WOS-026 and WOS-027 from features_deferred to features_completed
- Added commit references: fcfc427, f0aeb14, 84ac6f6

All documentation now accurately reflects the current state of the project with zero clippy warnings and comprehensive test coverage.