### PR TITLE
ci: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
     branches: [main]
 
 env:


### PR DESCRIPTION
Enables manual CI re-triggering via GitHub Actions UI or `gh workflow run`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>